### PR TITLE
fix: fetch up to 100 forks

### DIFF
--- a/docs/scripts/index.js
+++ b/docs/scripts/index.js
@@ -27,7 +27,7 @@ function renderStudents(students) {
 }
 
 async function getStudents() {
-    const res = await fetch('https://api.github.com/repos/cmda-minor-web/web-app-from-scratch-2324/forks')
+    const res = await fetch('https://api.github.com/repos/cmda-minor-web/web-app-from-scratch-2324/forks?per_page=100')
     const teams = await res.json()
     console.log(teams);
     return teams.map(({owner}) => owner)


### PR DESCRIPTION
Default `per_page` is 30 which is too little to fetch the forks of all students.

See https://docs.github.com/en/rest/repos/forks?apiVersion=2022-11-28